### PR TITLE
Add initial tshell AI shell package

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,13 @@
 # tshell
+
+`tshell` is a lightweight command line tool that lets you talk to an AI model
+from your terminal. It uses the OpenAI API if it is available and configured via
+`OPENAI_API_KEY`. When the API is unavailable, a placeholder response is
+returned instead.
+
+```
+$ tshell echo hello
+[AI] Response for: echo hello
+```
+
+Run `tshell` without arguments to enter an interactive shell.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,16 @@
+[build-system]
+requires = ["setuptools>=67", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "tshell"
+version = "0.1.0"
+description = "Simple AI shell tool"
+authors = [{name="AI", email="ai@example.com"}]
+readme = "README.md"
+license = {text = "MIT"}
+requires-python = ">=3.8"
+dependencies = ["openai>=0.28"]
+
+[project.scripts]
+tshell = "tshell.cli:main"

--- a/tshell/ai.py
+++ b/tshell/ai.py
@@ -1,0 +1,33 @@
+import os
+import logging
+
+try:
+    import openai
+except ImportError:  # pragma: no cover - fallback if openai not installed
+    openai = None
+
+log = logging.getLogger(__name__)
+
+
+def get_ai_response(prompt: str, model: str = "gpt-3.5-turbo") -> str:
+    """Get a response from the OpenAI API.
+
+    This requires the `openai` package and an `OPENAI_API_KEY` environment variable.
+    If the API key is missing or the package is unavailable, a placeholder response
+    will be returned.
+    """
+    api_key = os.getenv("OPENAI_API_KEY")
+    if not openai or not api_key:
+        log.debug("OpenAI not configured; returning placeholder response.")
+        return "[AI] Response for: " + prompt
+
+    openai.api_key = api_key
+    try:
+        chat_completion = openai.ChatCompletion.create(
+            model=model,
+            messages=[{"role": "user", "content": prompt}],
+        )
+        return chat_completion.choices[0].message["content"].strip()
+    except Exception as exc:  # pragma: no cover - network errors
+        log.error("Error communicating with OpenAI: %s", exc)
+        return "[AI] Error processing request"

--- a/tshell/cli.py
+++ b/tshell/cli.py
@@ -1,0 +1,45 @@
+import argparse
+import sys
+
+from .ai import get_ai_response
+
+
+def interactive_shell(model: str) -> int:
+    """Start an interactive AI shell."""
+    print("tshell AI shell. Type 'exit' to quit.")
+    while True:
+        try:
+            prompt = input('> ')
+        except EOFError:
+            break
+        if prompt.strip().lower() in {'exit', 'quit'}:
+            break
+        response = get_ai_response(prompt, model=model)
+        print(response)
+    return 0
+
+
+def main(argv=None) -> int:
+    parser = argparse.ArgumentParser(description="tshell: simple AI shell tool")
+    parser.add_argument(
+        "command",
+        nargs=argparse.REMAINDER,
+        help="Command to send to the AI (leave empty for interactive mode)",
+    )
+    parser.add_argument(
+        "--model",
+        default="gpt-3.5-turbo",
+        help="OpenAI model to use (default: gpt-3.5-turbo)",
+    )
+    args = parser.parse_args(argv)
+
+    if args.command:
+        prompt = " ".join(args.command)
+        print(get_ai_response(prompt, model=args.model))
+        return 0
+
+    return interactive_shell(args.model)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- add `tshell` package providing a simple AI shell via OpenAI
- create CLI with interactive mode or single command execution
- allow fallback when OpenAI isn't configured
- document usage in README
- add packaging info in `pyproject.toml`

## Testing
- `pip install -e .`
- `tshell --help`


------
https://chatgpt.com/codex/tasks/task_e_688d015acb6083289f4d187d09137510